### PR TITLE
FOUR-12366: No API key authentication configured! in Java scripts

### DIFF
--- a/src/ProcessMaker.java
+++ b/src/ProcessMaker.java
@@ -19,7 +19,7 @@ public class ProcessMaker {
 
         client.setBasePath(baseApiUrl);
         if(v3Token != null && !v3Token.isEmpty()) {
-            client.setApiKey("Bearer " + v3Token);
+            client.setBearerToken(v3Token);
         }
         client.setConnectTimeout(connectTimeout);
         client.setDebugging(false);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a new script and pick the ‘Java Executor' as the executor.

- Go to the editor and copy the 'Example Script Task'.

```
import ProcessMaker_Client.ApiClient;
import java.io.*;
import java.util.Map;
public class Script implements BaseScript {
    public void execute(Map<String, Object> data, Map<String, Object> config, Map<String, Object> output, ApiClient api) {
        Double x = (Double) data.get("x");
        Double y = (Double) data.get("y");
        Double z = x + y;
        output.put("z", z);
    }
}
```



- Then, copy the contents of 'Example data.json' from the link and paste them into the Sample Input of the script
```
{
  "x": 100,
  "y": 200
}
```
- Run the script.

An "No API key authentication configured! in Java scripts" message is printed in the output window.

## Description of the problem:

When making the next call in the executor (file ProcessMaker.java, line 22)
client.setApiKey("Bearer " + v3Token);
an error is thrown, because the SDK (the one that implements the setApiKey method) does not have an "ApiKey" authentication. The code in the SDK (file ApiClient.java) add just 2 authentications:
```
        // Setup authentications (key: authentication name, value: authentication).
        authentications.put("bearer", new HttpBearerAuth("bearer"));
        authentications.put("passport", new OAuth());
```
So the ApiKeyAuth isn't added.

## Solution
- Use the HttpBearerAuth authentication instead of  the ApiKeyAuth

## How to Test
- Use the reproduction steps and verify that the example script runs correctly

Image of the script running correctly with the fix:

![image](https://github.com/ProcessMaker/docker-executor-java/assets/14875032/e944b682-7bea-4c3b-a7dc-b571c805c8ee)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12366

