### PR TITLE
XPROJ-67: Adding installer option to skip docker executor building

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "processmaker/docker-executor-java",
     "friendly_name": "Java Docker Executor",
     "description": "Java script executor for processmaker 4",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {

--- a/src/DockerExecutorJavaServiceProvider.php
+++ b/src/DockerExecutorJavaServiceProvider.php
@@ -13,7 +13,7 @@ class DockerExecutorJavaServiceProvider extends ServiceProvider
 {
     use PluginServiceProviderTrait;
 
-    const version = '1.0.0'; // Required for PluginServiceProviderTrait
+    public const version = '1.0.5'; // Required for PluginServiceProviderTrait
 
     public function register()
     {
@@ -29,7 +29,7 @@ class DockerExecutorJavaServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Artisan::command('docker-executor-java:install', function () {
+        Artisan::command('docker-executor-java:install {--no-build : Skip building the script executor image}', function () {
             ScriptExecutor::install([
                 'language' => 'java',
                 'title' => 'Java Executor',
@@ -37,10 +37,13 @@ class DockerExecutorJavaServiceProvider extends ServiceProvider
             ]);
 
             // Build the instance image. This is the same as if you were to build it from the admin UI
-            Artisan::call('processmaker:build-script-executor java');
+            // Skip building the image if the --no-build option is passed
+            if (!$this->option('no-build')) {
+                Artisan::call('processmaker:build-script-executor java');
+            }
 
             // Restart the workers so they know about the new supported language
-            Artisan::call('horizon:terminate');
+            //Artisan::call('horizon:terminate');
         });
 
         config(['script-runners.java' => [


### PR DESCRIPTION
This change introduces a new option into the installer to avoid the execution of the Docker build command at installation time. This feature is required in environments where we are stopping using the Docker server (pods) or serverless.

Example of use:

Skip the Docker build command at installation time
`php artisan docker-executor-java:install --no-build`

To keep the same functionality
`php artisan docker-executor-java:install`